### PR TITLE
[RapidJson] Fix Windows build (#define GetObject in Windows headers)

### DIFF
--- a/include/bitserializer/rapidjson_archive.h
+++ b/include/bitserializer/rapidjson_archive.h
@@ -20,6 +20,15 @@
 #include "rapidjson/writer.h"
 #include "rapidjson/error/en.h"
 
+#ifdef GetObject
+// see https://github.com/Tencent/rapidjson/issues/1448
+// a former included windows.h might have defined a macro called GetObject, which affects
+// GetObject defined here. This ensures the macro does not get applied
+#pragma push_macro("GetObject")
+#define RAPIDJSON_WINDOWS_GETOBJECT_WORKAROUND_APPLIED
+#undef GetObject
+#endif
+
 namespace BitSerializer::Json::RapidJson {
 namespace Detail {
 
@@ -695,3 +704,8 @@ using JsonArchive = TArchiveBase<
 	Detail::RapidJsonRootScope<SerializeMode::Save>>;
 
 }
+
+#ifdef RAPIDJSON_WINDOWS_GETOBJECT_WORKAROUND_APPLIED
+#pragma pop_macro("GetObject")
+#undef RAPIDJSON_WINDOWS_GETOBJECT_WORKAROUND_APPLIED
+#endif


### PR DESCRIPTION
apply same fix as in
https://github.com/Tencent/rapidjson/blob/676d99db96e2108724e62342a47e28c8e991ed3b/include/rapidjson/document.h#L45